### PR TITLE
AEM6 support

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -3,43 +3,91 @@ driver_config:
   google_client_email: <%= ENV['GOOGLE_CLIENT_EMAIL'] %>
   google_key_location: <%= ENV['GOOGLE_KEY_LOCATION'] %>
   google_project: <%= ENV['GOOGLE_PROJECT'] %>
-  aws_access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
-  aws_secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
-  aws_ssh_key_id: <%= ENV['AWS_KEYPAIR_NAME'] %>
-  security_group_ids: [ 'sg-c823c0fb' ]
-
-  # This is required for AWS, but should not be specified if using GCE.
-  # All other fields can coexist peacefully.
-  ssh_key: <%= ENV['AWS_SSH_KEY_PATH'] %>
 
 provisioner:
   name: chef_zero
 
 platforms:
   - name: centos-6.5
-    driver_plugin: ec2
-    # driver_plugin: gce
+    driver_plugin: gce
     driver_config:
-      # AWS
-      image_id: 'ami-b6bdde86'
-      region: 'us-west-2'
-      availability_zone: 'us-west-2b'
-
       # GCE
       image_name: 'centos-6-v20140415'
       area: <%= ENV['GCE_AREA'] %>
       public_key_path: <%= ENV['GCE_PUBLIC_KEY_PATH'] %>
 
 suites:
-  - name: author-5.6.1-oraclejdk7
+  - name: author-6.0.0-oraclejdk7
     driver_config:
       machine_type: 'n1-standard-1'
-      flavor_id: 'm3.medium'
     run_list:
       - recipe[aem::author]
     attributes:
       aem:
-        # TODO: can we get rid of the need for the version variable, and infer that from the URL instead?
+        version: '6.0.0'
+        download_url: <%= ENV['AEM_DOWNLOAD_URL_600'] %>
+        license_url: <%= ENV['AEM_LICENSE_URL_600'] %>
+        author:
+          startup:
+            max_attempts: 40
+            wait_between_attempts: 30
+      java:
+        install_flavor: 'oracle'
+        jdk_version: '7'
+        oracle:
+          accept_oracle_download_terms: true
+  - name: publish-6.0.0-oraclejdk7
+    driver_config:
+      machine_type: 'n1-standard-1'
+    run_list:
+      - recipe[aem::publish]
+    attributes:
+      aem:
+        version: '6.0.0'
+        download_url: <%= ENV['AEM_DOWNLOAD_URL_600'] %>
+        license_url: <%= ENV['AEM_LICENSE_URL_600'] %>
+        publish:
+          startup:
+            max_attempts: 40
+            wait_between_attempts: 30
+      java:
+        install_flavor: 'oracle'
+        jdk_version: '7'
+        oracle:
+          accept_oracle_download_terms: true
+  - name: author-publish-6.0.0-oraclejdk7
+    driver_config:
+      machine_type: 'n1-standard-2'
+    run_list:
+      - recipe[aem::author]
+      - recipe[aem::publish]
+    attributes:
+      aem:
+        version: '6.0.0'
+        download_url: <%= ENV['AEM_DOWNLOAD_URL_600'] %>
+        license_url: <%= ENV['AEM_LICENSE_URL_600'] %>
+        author:
+          startup:
+            max_attempts: 40
+            wait_between_attempts: 30
+        publish:
+          startup:
+            max_attempts: 40
+            wait_between_attempts: 30
+      java:
+        install_flavor: 'oracle'
+        jdk_version: '7'
+        oracle:
+          accept_oracle_download_terms: true
+
+
+  - name: author-5.6.1-oraclejdk7
+    driver_config:
+      machine_type: 'n1-standard-1'
+    run_list:
+      - recipe[aem::author]
+    attributes:
+      aem:
         version: '5.6.1'
         download_url: <%= ENV['AEM_DOWNLOAD_URL_561'] %>
         license_url: <%= ENV['AEM_LICENSE_URL_561'] %>
@@ -55,12 +103,10 @@ suites:
   - name: publish-5.6.1-oraclejdk7
     driver_config:
       machine_type: 'n1-standard-1'
-      flavor_id: 'm3.medium'
     run_list:
       - recipe[aem::publish]
     attributes:
       aem:
-        # TODO: can we get rid of the need for the version variable, and infer that from the URL instead?
         version: '5.6.1'
         download_url: <%= ENV['AEM_DOWNLOAD_URL_561'] %>
         license_url: <%= ENV['AEM_LICENSE_URL_561'] %>
@@ -76,13 +122,11 @@ suites:
   - name: author-publish-5.6.1-oraclejdk7
     driver_config:
       machine_type: 'n1-standard-2'
-      flavor_id: 'm3.large'
     run_list:
       - recipe[aem::author]
       - recipe[aem::publish]
     attributes:
       aem:
-        # TODO: can we get rid of the need for the version variable, and infer that from the URL instead?
         version: '5.6.1'
         download_url: <%= ENV['AEM_DOWNLOAD_URL_561'] %>
         license_url: <%= ENV['AEM_LICENSE_URL_561'] %>
@@ -104,12 +148,10 @@ suites:
   - name: author-5.6.0-oraclejdk6
     driver_config:
       machine_type: 'n1-standard-1'
-      flavor_id: 'm3.medium'
     run_list:
       - recipe[aem::author]
     attributes:
       aem:
-        # TODO: can we get rid of the need for the version variable, and infer that from the URL instead?
         version: '5.6.0'
         download_url: <%= ENV['AEM_DOWNLOAD_URL_560'] %>
         license_url: <%= ENV['AEM_LICENSE_URL_560'] %>
@@ -125,12 +167,10 @@ suites:
   - name: publish-5.6.0-oraclejdk6
     driver_config:
       machine_type: 'n1-standard-1'
-      flavor_id: 'm3.medium'
     run_list:
       - recipe[aem::publish]
     attributes:
       aem:
-        # TODO: can we get rid of the need for the version variable, and infer that from the URL instead?
         version: '5.6.0'
         download_url: <%= ENV['AEM_DOWNLOAD_URL_560'] %>
         license_url: <%= ENV['AEM_LICENSE_URL_560'] %>
@@ -146,13 +186,11 @@ suites:
   - name: author-publish-5.6.0-oraclejdk6
     driver_config:
       machine_type: 'n1-standard-2'
-      flavor_id: 'm3.large'
     run_list:
       - recipe[aem::author]
       - recipe[aem::publish]
     attributes:
       aem:
-        # TODO: can we get rid of the need for the version variable, and infer that from the URL instead?
         version: '5.6.0'
         download_url: <%= ENV['AEM_DOWNLOAD_URL_560'] %>
         license_url: <%= ENV['AEM_LICENSE_URL_560'] %>
@@ -174,12 +212,10 @@ suites:
   - name: author-5.5.0-oraclejdk6
     driver_config:
       machine_type: 'n1-standard-1'
-      flavor_id: 'm3.medium'
     run_list:
       - recipe[aem::author]
     attributes:
       aem:
-        # TODO: can we get rid of the need for the version variable, and infer that from the URL instead?
         version: '5.5.0'
         download_url: <%= ENV['AEM_DOWNLOAD_URL_550'] %>
         license_url: <%= ENV['AEM_LICENSE_URL_550'] %>
@@ -195,12 +231,10 @@ suites:
   - name: publish-5.5.0-oraclejdk6
     driver_config:
       machine_type: 'n1-standard-1'
-      flavor_id: 'm3.medium'
     run_list:
       - recipe[aem::publish]
     attributes:
       aem:
-        # TODO: can we get rid of the need for the version variable, and infer that from the URL instead?
         version: '5.5.0'
         download_url: <%= ENV['AEM_DOWNLOAD_URL_550'] %>
         license_url: <%= ENV['AEM_LICENSE_URL_550'] %>
@@ -216,13 +250,11 @@ suites:
   - name: author-publish-5.5.0-oraclejdk6
     driver_config:
       machine_type: 'n1-standard-2'
-      flavor_id: 'm3.large'
     run_list:
       - recipe[aem::author]
       - recipe[aem::publish]
     attributes:
       aem:
-        # TODO: can we get rid of the need for the version variable, and infer that from the URL instead?
         version: '5.5.0'
         download_url: <%= ENV['AEM_DOWNLOAD_URL_550'] %>
         license_url: <%= ENV['AEM_LICENSE_URL_550'] %>
@@ -244,9 +276,6 @@ suites:
   - name: dispatcher
     driver_config:
       machine_type: 'f1-micro'
-      # machine_type: 'g1-small'
-      flavor_id: 't1.micro'
-      # flavor_id: 'm1.small'
     run_list:
       - recipe[aem::dispatcher]
     attributes:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -11,6 +11,65 @@ platforms:
   - name: centos-6.5
 
 suites:
+  - name: author-6.0.0-oraclejdk7
+    driver:
+      customize:
+        memory: '2560'
+    run_list:
+      - recipe[aem::author]
+    attributes:
+      aem:
+        version: '6.0.0'
+        download_url: <%= ENV['AEM_DOWNLOAD_URL_600'] %>
+        license_url: <%= ENV['AEM_LICENSE_URL_600'] %>
+      java:
+        install_flavor: 'oracle'
+        jdk_version: '7'
+        oracle:
+          accept_oracle_download_terms: true
+  - name: publish-6.0.0-oraclejdk7
+    driver:
+      customize:
+        memory: '2560'
+    run_list:
+      - recipe[aem::publish]
+    attributes:
+      aem:
+        version: '6.0.0'
+        download_url: <%= ENV['AEM_DOWNLOAD_URL_600'] %>
+        license_url: <%= ENV['AEM_LICENSE_URL_600'] %>
+      java:
+        install_flavor: 'oracle'
+        jdk_version: '7'
+        oracle:
+          accept_oracle_download_terms: true
+  - name: author-publish-6.0.0-oraclejdk7
+    driver:
+      customize:
+        memory: '5120'
+    run_list:
+      - recipe[aem::author]
+      - recipe[aem::publish]
+    attributes:
+      aem:
+        version: '6.0.0'
+        download_url: <%= ENV['AEM_DOWNLOAD_URL_600'] %>
+        license_url: <%= ENV['AEM_LICENSE_URL_600'] %>
+        author:
+          startup:
+            max_attempts: 40
+            wait_between_attempts: 30
+        publish:
+          startup:
+            max_attempts: 40
+            wait_between_attempts: 30
+      java:
+        install_flavor: 'oracle'
+        jdk_version: '7'
+        oracle:
+          accept_oracle_download_terms: true
+
+
   - name: author-5.6.1-oraclejdk7
     driver:
       customize:
@@ -19,7 +78,6 @@ suites:
       - recipe[aem::author]
     attributes:
       aem:
-        # TODO: can we get rid of the need for the version variable, and infer that from the URL instead?
         version: '5.6.1'
         download_url: <%= ENV['AEM_DOWNLOAD_URL_561'] %>
         license_url: <%= ENV['AEM_LICENSE_URL_561'] %>
@@ -36,7 +94,6 @@ suites:
       - recipe[aem::publish]
     attributes:
       aem:
-        # TODO: can we get rid of the need for the version variable, and infer that from the URL instead?
         version: '5.6.1'
         download_url: <%= ENV['AEM_DOWNLOAD_URL_561'] %>
         license_url: <%= ENV['AEM_LICENSE_URL_561'] %>
@@ -54,7 +111,6 @@ suites:
       - recipe[aem::publish]
     attributes:
       aem:
-        # TODO: can we get rid of the need for the version variable, and infer that from the URL instead?
         version: '5.6.1'
         download_url: <%= ENV['AEM_DOWNLOAD_URL_561'] %>
         license_url: <%= ENV['AEM_LICENSE_URL_561'] %>
@@ -73,7 +129,6 @@ suites:
       - recipe[aem::author]
     attributes:
       aem:
-        # TODO: can we get rid of the need for the version variable, and infer that from the URL instead?
         version: '5.6.0'
         download_url: <%= ENV['AEM_DOWNLOAD_URL_560'] %>
         license_url: <%= ENV['AEM_LICENSE_URL_560'] %>
@@ -90,7 +145,6 @@ suites:
       - recipe[aem::publish]
     attributes:
       aem:
-        # TODO: can we get rid of the need for the version variable, and infer that from the URL instead?
         version: '5.6.0'
         download_url: <%= ENV['AEM_DOWNLOAD_URL_560'] %>
         license_url: <%= ENV['AEM_LICENSE_URL_560'] %>
@@ -108,7 +162,6 @@ suites:
       - recipe[aem::publish]
     attributes:
       aem:
-        # TODO: can we get rid of the need for the version variable, and infer that from the URL instead?
         version: '5.6.0'
         download_url: <%= ENV['AEM_DOWNLOAD_URL_560'] %>
         license_url: <%= ENV['AEM_LICENSE_URL_560'] %>
@@ -127,7 +180,6 @@ suites:
       - recipe[aem::author]
     attributes:
       aem:
-        # TODO: can we get rid of the need for the version variable, and infer that from the URL instead?
         version: '5.5.0'
         download_url: <%= ENV['AEM_DOWNLOAD_URL_550'] %>
         license_url: <%= ENV['AEM_LICENSE_URL_550'] %>
@@ -144,7 +196,6 @@ suites:
       - recipe[aem::publish]
     attributes:
       aem:
-        # TODO: can we get rid of the need for the version variable, and infer that from the URL instead?
         version: '5.5.0'
         download_url: <%= ENV['AEM_DOWNLOAD_URL_550'] %>
         license_url: <%= ENV['AEM_LICENSE_URL_550'] %>
@@ -162,7 +213,6 @@ suites:
       - recipe[aem::publish]
     attributes:
       aem:
-        # TODO: can we get rid of the need for the version variable, and infer that from the URL instead?
         version: '5.5.0'
         download_url: <%= ENV['AEM_DOWNLOAD_URL_550'] %>
         license_url: <%= ENV['AEM_LICENSE_URL_550'] %>

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ This cookbook installs and configures [Adobe Experience Manager (AEM)](http://ww
 
 * CentOS
 
+## Supported Versions
+
+* AEM 6.0.0
+* AEM 5.6.1
+* AEM 5.6.0
+* CQ 5.5.0
+
 ## Attributes
 
 <table>

--- a/recipes/author.rb
+++ b/recipes/author.rb
@@ -51,6 +51,7 @@ end
 service "aem-author" do
   #init script returns 0 for status no matter what
   status_command "service aem-author status | grep running"
+  supports :status => true, :stop => true, :start => true, :restart => true
   action [ :enable, :start ]
 end
 

--- a/recipes/publish.rb
+++ b/recipes/publish.rb
@@ -51,6 +51,7 @@ end
 service "aem-publish" do
   #init script returns 0 for status no matter what
   status_command "service aem-publish status | grep running"
+  supports :status => true, :stop => true, :start => true, :restart => true
   action [:enable, :start]
 end
 

--- a/templates/default/init.erb
+++ b/templates/default/init.erb
@@ -554,13 +554,16 @@ server=y,suspend=${CQ_JVM_DEBUG_SUSPENDED}"
     fi;
 
     COUNTER=0
-    while ps -p $cqpid > /dev/null 2>&1 && [ $COUNTER -lt 60 ]; do
+    # AEM6 takes a very long time to stop after the first run. Subsequent stops are usually much quicker.
+    TIMEOUT_SECONDS=300
+    while ps -p $cqpid > /dev/null 2>&1 && [ $COUNTER -lt ${TIMEOUT_SECONDS} ]; do
         printf "."
         COUNTER=`expr $COUNTER + 1`
         sleep 2
     done
     if ps -p $cqpid > /dev/null 2>&1; then
         echo "Process $cqpid still running, unable to stop"
+        exit 20
     else
         echo "stopped."
         rm -f "$CQ_LOGDIR/cq.pid"

--- a/test/integration/author-6.0.0-oraclejdk7/serverspec/cq_author_daemon_spec.rb
+++ b/test/integration/author-6.0.0-oraclejdk7/serverspec/cq_author_daemon_spec.rb
@@ -1,0 +1,16 @@
+require 'serverspec'
+
+include Serverspec::Helper::Exec
+include Serverspec::Helper::DetectOS
+
+describe 'AEM Author Daemon' do
+
+  it 'is listening on port 4502' do
+    expect(port(4502)).to be_listening
+  end
+
+  it 'has a running service of aem-author' do
+    expect(service('aem-author')).to be_running
+  end
+
+end

--- a/test/integration/author-publish-6.0.0-oraclejdk7/serverspec/cq_author_daemon_spec.rb
+++ b/test/integration/author-publish-6.0.0-oraclejdk7/serverspec/cq_author_daemon_spec.rb
@@ -1,0 +1,16 @@
+require 'serverspec'
+
+include Serverspec::Helper::Exec
+include Serverspec::Helper::DetectOS
+
+describe 'AEM Author Daemon' do
+
+  it 'is listening on port 4502' do
+    expect(port(4502)).to be_listening
+  end
+
+  it 'has a running service of aem-author' do
+    expect(service('aem-author')).to be_running
+  end
+
+end

--- a/test/integration/author-publish-6.0.0-oraclejdk7/serverspec/cq_publish_daemon_spec.rb
+++ b/test/integration/author-publish-6.0.0-oraclejdk7/serverspec/cq_publish_daemon_spec.rb
@@ -1,0 +1,16 @@
+require 'serverspec'
+
+include Serverspec::Helper::Exec
+include Serverspec::Helper::DetectOS
+
+describe 'AEM Publish Daemon' do
+
+  it 'is listening on port 4503' do
+    expect(port(4503)).to be_listening
+  end
+
+  it 'has a running service of aem-publish' do
+    expect(service('aem-publish')).to be_running
+  end
+
+end

--- a/test/integration/publish-6.0.0-oraclejdk7/serverspec/cq_publish_daemon_spec.rb
+++ b/test/integration/publish-6.0.0-oraclejdk7/serverspec/cq_publish_daemon_spec.rb
@@ -1,0 +1,16 @@
+require 'serverspec'
+
+include Serverspec::Helper::Exec
+include Serverspec::Helper::DetectOS
+
+describe 'AEM Publish Daemon' do
+
+  it 'is listening on port 4503' do
+    expect(port(4503)).to be_listening
+  end
+
+  it 'has a running service of aem-publish' do
+    expect(service('aem-publish')).to be_running
+  end
+
+end


### PR DESCRIPTION
- Add kitchen tests for AEM6.
- Stopping the AEM6 process takes a bit longer the first time, so bumped the stop timeout in the init script to keep that from failing.
- Add supported versions to readme.
