### PR TITLE
Update jar_installer.rb

### DIFF
--- a/providers/jar_installer.rb
+++ b/providers/jar_installer.rb
@@ -48,9 +48,10 @@ action :install do
   end
   r.run_action(:create_if_missing)
 
-  file "#{vars[:base_dir]}/#{service_name}/#{jar_name}" do
-    content IO.read("#{Chef::Config[:file_cache_path]}/#{remote_jar_name}")
+  remote_file "#{vars[:base_dir]}/#{service_name}/#{jar_name}" do
+    source "file://#{Chef::Config[:file_cache_path]}/#{remote_jar_name}"
     mode "0755"
+    action :create_if_missing
   end
 
   bash "unpack jar" do


### PR DESCRIPTION
The IO.read method reads the entire JAR file into RAM.  In our environment the jar file is roughly 900MB.  This was causing Out of Memory exceptions on our machines.

This proposed change will leverage the remote_file resource and the source attribute. The file is still read from the local cache directory. The file is buffered much more effectively when taking this approach.

I also propose updating the action to only create the file if it is missing.

This change reduced the memory consumption of this resource by more than an order of magnitude. This change also reduced the execution duration for this resource by roughly 10 seconds in our environment.

Please let me know if you have any questions.
