### PR TITLE
adding support for apache header

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -215,3 +215,4 @@ default[:aem][:dispatcher][:enable_session_mgmt] = false
 default[:aem][:dispatcher][:mod_dispatcher_url] = nil
 default[:aem][:dispatcher][:mod_dispatcher_checksum] = nil
 default[:aem][:dispatcher][:deflate_enabled] = true
+default[:aem][:dispatcher][:header] = []

--- a/providers/website.rb
+++ b/providers/website.rb
@@ -26,7 +26,7 @@ action :add do
     :site_name, :server_name, :server_aliases, :aem_locations, :cache_root,
     :enabled, :rewrites, :listen_port, :ssl_enabled, :ssl_cert_file,
     :ssl_key_file, :expire_dirs, :enable_etag, :enable_ie_header,
-    :template_cookbook, :template_name, :deflate_enabled, :local_vars
+    :template_cookbook, :template_name, :deflate_enabled, :local_vars, :header
   ]
   var_list.each do |var|
     vars[var] = new_resource.send(var) || node[:aem][:dispatcher][var]
@@ -59,6 +59,7 @@ action :add do
     deflate_enabled vars[:deflate_enabled]
     local_vars vars[:local_vars]
     enable vars[:enabled]
+    header vars[:header]
   end
 end
 

--- a/resources/website.rb
+++ b/resources/website.rb
@@ -39,3 +39,4 @@ attribute :template_cookbook, :kind_of => String, :default => 'aem'
 attribute :template_name, :kind_of => String, :default => 'aem_dispatcher.conf.erb'
 attribute :deflate_enabled, :kind_of => [TrueClass, FalseClass ], :default => false
 attribute :local_vars, :kind_of => Hash, :default => nil
+attribute :header, :kind_of => Array, :default => nil

--- a/templates/default/aem_dispatcher.conf.erb
+++ b/templates/default/aem_dispatcher.conf.erb
@@ -121,4 +121,8 @@
   RewriteLog <%= node[:apache][:log_dir] %>/<%= @application_name %>-rewrite.log
   RewriteLogLevel 0
 
+  <% @params[:header].each do |head| %>
+  <%= head %>
+  <% end %>
+
 </VirtualHost>


### PR DESCRIPTION
this is an example test attribute:

default['aem']['dispatcher']['header'] = ['Header always append X-Frame-Options SAMEORIGIN']

Then hit a page through the dispatcher. It the network console you should see this:

![x-frame-options](https://cloud.githubusercontent.com/assets/583935/6740133/fc085d86-ce3a-11e4-8f8d-dcebd1d9ba96.png)
