### PR TITLE
Loosen Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,5 @@ gem 'kitchen-vagrant', '~> 0.16'
 gem 'rake', '~> 10.4'
 gem 'rubocop', '~> 0.29'
 gem 'stove', '~> 3.2', '>= 3.2.3'
+gem 'test-kitchen', '~> 1.3', '>= 1.3.1'
 gem 'thor-scmversion', '~> 1.7.0'
-
-# v1.2.1 (latest stable) is somewhat broken when working with AWS. Fixes are in master, so
-# I'm locking to a specific working commit until a newer release is created.
-gem 'test-kitchen', :git => 'https://github.com/test-kitchen/test-kitchen.git', :ref => '3d3d024443e89bb5a7182e22b5ce2e59b8964853'

--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,14 @@
 source 'https://rubygems.org'
 
-gem 'berkshelf', '= 3.1.5'
-gem 'chefspec', '= 4.1.1'
-gem 'foodcritic', '= 4.0.0'
-gem 'kitchen-gce', '= 0.1.2'
-gem 'kitchen-vagrant', '= 0.15.0'
-gem 'rake', '= 10.3.2'
-gem 'rubocop', '= 0.26.1'
-gem 'stove', '= 3.2.3'
-gem 'thor-scmversion', '= 1.7.0'
+gem 'berkshelf', '~> 3.2'
+gem 'chefspec', '~> 4.2'
+gem 'foodcritic', '~> 4.0'
+gem 'kitchen-gce', '= 0.2'
+gem 'kitchen-vagrant', '~> 0.16'
+gem 'rake', '~> 10.4'
+gem 'rubocop', '~> 0.29'
+gem 'stove', '~> 3.2', '>= 3.2.3'
+gem 'thor-scmversion', '~> 1.7.0'
 
 # v1.2.1 (latest stable) is somewhat broken when working with AWS. Fixes are in master, so
 # I'm locking to a specific working commit until a newer release is created.


### PR DESCRIPTION
The Gemfile specified a hard lock on every version. If you would really need this, then the solution would be to commit the Gemfile.lock, as this is exactly the reason why this file exists.

Normally, this hard lock is not necessary, as most gems should follow semver.

I loosened all version locks in the Gemfile. This is just partly tested.