### PR TITLE
updates to support ignoreUrlParams in dispatcher cache configs

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -190,6 +190,7 @@ default[:aem][:dispatcher][:invalidation_rules] = {
     "0001" => { :glob => "*.html", :type => "allow" }
   }
 default[:aem][:dispatcher][:allowed_clients] = {}
+default[:aem][:dispatcher][:ignore_url_params] = {}
 default[:aem][:dispatcher][:statistics] = [
     { :name => "html", :glob => "*.html" },
     { :name => "others", :glob => "*" },

--- a/providers/farm.rb
+++ b/providers/farm.rb
@@ -26,6 +26,7 @@ action :add do
                :renders => :array, :statistics => :array,
                :filter_rules => :hash, :cache_rules=> :hash,
                :invalidation_rules => :hash, :allowed_clients => :hash,
+               :ignore_url_params => :hash,
                :cache_root => :scalar, :farm_dir => :scalar,
                :farm_name => :scalar, :cache_opts => :array,
                :session_mgmt => :hash, :enable_session_mgmt => :scalar }

--- a/resources/farm.rb
+++ b/resources/farm.rb
@@ -28,6 +28,7 @@ attribute :farm_dir, :kind_of => String, :default => nil
 attribute :cache_rules, :kind_of => Hash, :default => nil
 attribute :invalidation_rules, :kind_of => Hash, :default => nil
 attribute :allowed_clients, :kind_of => Hash, :default => nil
+attribute :ignore_url_params, :kind_of => Hash, :default => nil
 attribute :statistics, :kind_of => Array, :default => nil
 attribute :cache_opts, :kind_of => Array, :default => nil
 attribute :session_mgmt, :kind_of => Hash, :default => nil

--- a/templates/default/farm.any.erb
+++ b/templates/default/farm.any.erb
@@ -68,6 +68,16 @@
           }
       <% end %>
       }
+    /ignoreUrlParams
+      {
+      <% @ignore_url_params.keys.sort.each do |rule_number| %>
+        /<%= rule_number %>
+          {
+            /glob "<%= @ignore_url_params[rule_number][:glob] %>"
+            /type "<%= @ignore_url_params[rule_number][:type] %>"
+          }
+      <% end %>
+      } 
     }
   /statistics
     {


### PR DESCRIPTION
This pull request will allow for the aem-cookbook to include a ignoreUrlParams section, which defines which URL parameters are ignored when determining whether a page is cached or delivered from cache.

More details on ignoring url parameters can be found here in the "Configuration DIspatcher" documentation from Adobe: https://docs.adobe.com/docs/en/dispatcher/disp-config.html