### PR TITLE
allow aem_jar_installer to check for a subdirectory in base_dir/crx-q…

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -60,6 +60,10 @@ default[:aem][:commands] = {
     :aem55 => 'curl -u <%= admin_user %>:<%= admin_password %> -FcreateUser= -FauthorizableId=<%= user %> -Frep:password=<%= password %> -Fmembership=<%= group %> http://localhost:<%= port %>/libs/granite/security/post/authorizables'
   }
 }
+
+# used in the aem_jar_installer to allow for a more fine grain check to determine if an unpack is necessary or not
+default[:aem][:unpack_jar_dir] = "crx-quickstart"
+
 default[:aem][:author] = {
   :default_context => "/opt/aem/author",
   :port => "4502",

--- a/providers/jar_installer.rb
+++ b/providers/jar_installer.rb
@@ -58,5 +58,5 @@ action :install do
     user "crx"
     cwd vars[:default_context]
     code "java -jar #{jar_name} -unpack"
-  end unless Object::File.exists?("#{vars[:default_context]}/crx-quickstart")
+  end unless Object::File.exists?("#{vars[:default_context]}/#{node[:aem][:unpack_jar_dir]}")
 end


### PR DESCRIPTION
…uickstart to determine whether to unpack the .jar file or not

I have a use case in which I'd like to do some pre-setup work with the crx-quickstart directory before running the author / publish recipe. However given how the current aem_jar_installer provider is set up, it's locked into checking for the crx-quickstart directory and the crx-quickstart directory alone.  I'd like to have this folder be parameterized with an attribute so that users will have a finer grain option should they choose to do so.