### PR TITLE
FIX: in AEM 6.1, querying for user path to set password

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -51,7 +51,8 @@ default[:aem][:commands] = {
   :password => {
     :aem54 => 'curl -f --data rep:password=<%= password %> --user <%= admin_user %>:<%= admin_password %> http://localhost:<%= port %><%= path %>/<%= user %>',
     :aem55 => 'curl -f --user <%= admin_user %>:<%= admin_password %> -F rep:password="<%= password %>" http://localhost:<%= port %><%= path %>/<%= user %>.rw.html',
-    :aem60 => 'curl -u <%= admin_user %>:<%= admin_password %> -Fplain=<%= password %> -Fverify=<%= password %> -Fold=<%= admin_password %> -FPath=<%= path %>/<%= admin_user %> http://localhost:<%= port %>/crx/explorer/ui/setpassword.jsp'
+    :aem60 => 'curl -u <%= admin_user %>:<%= admin_password %> -Fplain=<%= password %> -Fverify=<%= password %> -Fold=<%= admin_password %> -FPath=<%= path %>/<%= admin_user %> http://localhost:<%= port %>/crx/explorer/ui/setpassword.jsp',
+    :aem61 => 'curl -u <%= admin_user %>:<%= admin_password %> -Fplain=<%= password %> -Fverify=<%= password %> -Fold=<%= admin_password %> -FPath=<%= path %> http://localhost:<%= port %>/crx/explorer/ui/setpassword.jsp',
   },
   :remove_user => {
     :aem55 => 'curl -u <%= admin_user %>:<%= admin_password %> -FdeleteAuthorizable= http://localhost:<%= port %><%= path %>/<%= user %>'


### PR DESCRIPTION
Starting 6.1, Authorizable node names are random. E.g. before it was /home/users/a/admin - new it could look like /home/users/a/arutil_OVX5Vkpxp4efa. To address this, we are querying to get the user path.

https://docs.adobe.com/docs/en/aem/6-1/release-notes/deprecated-removed-features.html