### PR TITLE
Add 5.6 curl command to set passwords.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -51,6 +51,7 @@ default[:aem][:commands] = {
   :password => {
     :aem54 => 'curl -f --data rep:password=<%= password %> --user <%= admin_user %>:<%= admin_password %> http://localhost:<%= port %><%= path %>/<%= user %>',
     :aem55 => 'curl -f --user <%= admin_user %>:<%= admin_password %> -F rep:password="<%= password %>" http://localhost:<%= port %><%= path %>/<%= user %>.rw.html',
+    :aem56 => 'curl -u <%= admin_user %>:<%= admin_password %> -F rep:password="<%= password %>" -F :currentPassword="<%= old_password %>" http://localhost:<%= port %><%= path %>/<%= user %>.rw.html',
     :aem60 => 'curl -u <%= admin_user %>:<%= admin_password %> -Fplain=<%= password %> -Fverify=<%= password %> -Fold=<%= admin_password %> -FPath=<%= path %>/<%= admin_user %> http://localhost:<%= port %>/crx/explorer/ui/setpassword.jsp',
     :aem61 => 'curl -u <%= admin_user %>:<%= admin_password %> -Fplain=<%= password %> -Fverify=<%= password %> -Fold=<%= admin_password %> -FPath=<%= path %> http://localhost:<%= port %>/crx/explorer/ui/setpassword.jsp',
   },

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -54,18 +54,20 @@ action :set_password do
 
 
   user,password,admin_user,admin_password,port,aem_version,path,group = set_vars
-  
+
 
   case
   when aem_version.to_f >= 6.1
     path = get_usr_path(port, user, admin_user, admin_password)
-    cmd = ERB.new(node[:aem][:commands][:password][:aem61]).result(binding) 
-    Chef::Log.info(cmd) 
+    cmd = ERB.new(node[:aem][:commands][:password][:aem61]).result(binding)
+    Chef::Log.info(cmd)
   when aem_version.to_f == 6.0
     cmd = ERB.new(node[:aem][:commands][:password][:aem60]).result(binding)
+  when aem_version.to_f > 5.5
+    cmd = ERB.new(node[:aem][:commands][:password][:aem56]).result(binding)
   when aem_version.to_f > 5.4
     cmd = ERB.new(node[:aem][:commands][:password][:aem55]).result(binding)
-  else 
+  else
     cmd = ERB.new(node[:aem][:commands][:password][:aem54]).result(binding)
   end
 


### PR DESCRIPTION
The curl command to set passwords is a tiny bit different for CQ 5.6.x, so this adds that in. The current logic (in 5.6.1) ends up using the `node[:aem][:commands][:password][:aem55]` version, and that fails with a 500 server error.