### PR TITLE
Update build dependencies.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,15 +1,12 @@
 source 'https://rubygems.org'
 
-gem 'berkshelf', '= 3.1.5'
-gem 'chefspec', '= 4.1.1'
+gem 'berkshelf', '= 3.3.0'
+gem 'chefspec', '= 4.3.0'
 gem 'foodcritic', '= 4.0.0'
-gem 'kitchen-gce', '= 0.1.2'
-gem 'kitchen-vagrant', '= 0.15.0'
-gem 'rake', '= 10.3.2'
-gem 'rubocop', '= 0.26.1'
-gem 'stove', '= 3.2.3'
+gem 'kitchen-gce', '= 0.2.0'
+gem 'kitchen-vagrant', '= 0.18.0'
+gem 'rake', '= 10.4.2'
+gem 'rubocop', '= 0.33.0'
+gem 'stove', '= 3.2.7'
+gem 'test-kitchen', '= 1.4.2'
 gem 'thor-scmversion', '= 1.7.0'
-
-# v1.2.1 (latest stable) is somewhat broken when working with AWS. Fixes are in master, so
-# I'm locking to a specific working commit until a newer release is created.
-gem 'test-kitchen', :git => 'https://github.com/test-kitchen/test-kitchen.git', :ref => '3d3d024443e89bb5a7182e22b5ce2e59b8964853'


### PR DESCRIPTION
This just updates the build dependencies to the latest and greatest. It also removes the need to depend on the git repo version of test-kitchen, since a fixed release happened a while back. ;-)