### PR TITLE
Refactor node[:aem][:commands] and providers to allow commands for various AEM versions to be driven by attributes.

### DIFF
--- a/providers/user.rb
+++ b/providers/user.rb
@@ -52,24 +52,15 @@ end
 
 action :set_password do
 
-
   user,password,admin_user,admin_password,port,aem_version,path,group = set_vars
-
 
   case
   when aem_version.to_f >= 6.1
     path = get_usr_path(port, user, admin_user, admin_password)
-    cmd = ERB.new(node[:aem][:commands][:password][:aem61]).result(binding)
-    Chef::Log.info(cmd)
-  when aem_version.to_f == 6.0
-    cmd = ERB.new(node[:aem][:commands][:password][:aem60]).result(binding)
-  when aem_version.to_f > 5.5
-    cmd = ERB.new(node[:aem][:commands][:password][:aem56]).result(binding)
-  when aem_version.to_f > 5.4
-    cmd = ERB.new(node[:aem][:commands][:password][:aem55]).result(binding)
-  else
-    cmd = ERB.new(node[:aem][:commands][:password][:aem54]).result(binding)
   end
+
+  aem_command = AEM::Helpers.retrieve_command_for_version(node[:aem][:commands][:password], aem_version)
+  cmd = ERB.new(aem_command).result(binding)
 
   runner = Mixlib::ShellOut.new(cmd)
   runner.run_command
@@ -80,11 +71,8 @@ action :remove do
 
   user,password,admin_user,admin_password,port,aem_version,path,group = set_vars
 
-  if aem_version.to_f > 5.4
-    cmd = ERB.new(node[:aem][:commands][:remove_user][:aem55]).result(binding)
-  else
-    raise "Action aem_user :remove is not implemented for AEM < 5.5.  If you know the proper curl command, please implement it in the provider."
-  end
+  aem_command = AEM::Helpers.retrieve_command_for_version(node[:aem][:commands][:remove_user], aem_version)
+  cmd = ERB.new(aem_command).result(binding)
 
   runner = Mixlib::ShellOut.new(cmd)
   runner.run_command
@@ -95,11 +83,8 @@ action :add do
 
   user,password,admin_user,admin_password,port,aem_version,path,group = set_vars
 
-  if aem_version.to_f > 5.4
-    cmd = ERB.new(node[:aem][:commands][:add_user][:aem55]).result(binding)
-  else
-    raise "Action aem_user :add is not implemented for AEM < 5.5.  If you know the proper curl command, please implement it in the provider."
-  end
+  aem_command = AEM::Helpers.retrieve_command_for_version(node[:aem][:commands][:add_user], aem_version)
+  cmd = ERB.new(aem_command).result(binding)
 
   runner = Mixlib::ShellOut.new(cmd)
   runner.run_command

--- a/recipes/author.rb
+++ b/recipes/author.rb
@@ -155,6 +155,7 @@ aem_replicator "delete_extra_replication_agents" do
   dynamic_cluster node[:aem][:author][:find_replication_hosts_dynamically]
   cluster_name node[:aem][:cluster_name]
   cluster_role node[:aem][:publish][:cluster_role]
+  aem_version node[:aem][:version]
   type :agent
   action :remove
 end
@@ -168,6 +169,7 @@ aem_replicator "create_replication_agents_for_publish_servers" do
   dynamic_cluster node[:aem][:author][:find_replication_hosts_dynamically]
   cluster_name node[:aem][:cluster_name]
   cluster_role node[:aem][:publish][:cluster_role]
+  aem_version node[:aem][:version]
   type :agent
   action :add
 end
@@ -181,6 +183,7 @@ aem_replicator "replicate_to_publish_servers" do
   dynamic_cluster node[:aem][:author][:find_replication_hosts_dynamically]
   cluster_name node[:aem][:cluster_name]
   cluster_role node[:aem][:publish][:cluster_role]
+  aem_version node[:aem][:version]
   type :publish
   action :add
 end

--- a/recipes/publish.rb
+++ b/recipes/publish.rb
@@ -155,6 +155,7 @@ aem_replicator "create_flush_agents" do
   dynamic_cluster node[:aem][:publish][:find_cache_hosts_dynamically]
   cluster_name node[:aem][:cluster_name]
   cluster_role node[:aem][:dispatcher][:cluster_role]
+  aem_version node[:aem][:version]
   type :flush_agent
   action :add
 end
@@ -168,6 +169,7 @@ aem_replicator "flush_cache" do
   dynamic_cluster node[:aem][:publish][:find_cache_hosts_dynamically]
   cluster_name node[:aem][:cluster_name]
   cluster_role node[:aem][:dispatcher][:cluster_role]
+  aem_version node[:aem][:version]
   type :flush
   action :add
 end

--- a/resources/replicator.rb
+++ b/resources/replicator.rb
@@ -28,3 +28,4 @@ attribute :cluster_name, :kind_of => String, :default => nil
 attribute :cluster_role, :kind_of => String, :default => nil
 attribute :type, :kind_of => Symbol, :default => nil
 attribute :server, :kind_of => String, :default => nil
+attribute :aem_version, :kind_of => String, :default => nil


### PR DESCRIPTION
Note that this is technically a breaking change, since this changes the format of the `node[:aem][:commands]` hash. But this (hopefully) will allow for easier future changes, since the code before required changes to both the hash and the providers (adding to the various case statements, etc.).

I also added in the correct curl commands for AEM 5.6.1, since those didn't exist in there prior to this.