### PR TITLE
Fix manage_home in user provider.

### DIFF
--- a/recipes/_base_aem_setup.rb
+++ b/recipes/_base_aem_setup.rb
@@ -67,7 +67,7 @@ else
     system true
     shell '/bin/bash'
     home '/home/crx'
-    supports manage_home: true
+    manage_home true
     action :create
   end
 end


### PR DESCRIPTION
It looks like chef-client 12.14.x+ broke this way that `manage_home` used to work (see https://github.com/chef/chef/issues/5318).

It looks like that's been fixed in more recent versions of chef-client, but this will likely break in Chef 13, so this fixes issues with any recent versions of chef-client with this problem as well as problems that will likely happen with this specific code when Chef 13 comes out.