### PR TITLE
Custom replicator params

### DIFF
--- a/libraries/aem_helpers.rb
+++ b/libraries/aem_helpers.rb
@@ -57,6 +57,17 @@ class AEM
 
         matching_command
       end
+
+      def add_replicator_params(current_command, replicator_params)
+        if !replicator_params.empty?
+          replicator_params.each do |param|
+            current_command = current_command + ' ' + param
+          end
+        end
+
+        current_command
+      end
+
     end
   end
 end

--- a/providers/replicator.rb
+++ b/providers/replicator.rb
@@ -78,10 +78,18 @@ action :add do
       agent_id_param = ''
     else
       log "Agent id found #{h[:agent_id]}, populate the userId value for the replication agent with it"
-      agent_id_param = "-F \"jcr:content/userId=#{h[:agent_id]}\""
+      agent_id_param = "-F \"userId=#{h[:agent_id]}\""
     end
 
     aem_command = AEM::Helpers.retrieve_command_for_version(node[:aem][:commands][:replicators][type][:add], aem_version)
+    aem_command = AEM::Helpers.add_replicator_params(aem_command, replicator_params)
+
+    # add agent_id_param to aem_command
+    case type
+    when :flush
+      aem_command = aem_command + ' ' + agent_id_param
+    end
+
     cmd = ERB.new(aem_command).result(binding)
 
     log "Adding replication agent with command: #{cmd}"

--- a/resources/replicator.rb
+++ b/resources/replicator.rb
@@ -29,3 +29,4 @@ attribute :cluster_role, kind_of: String, default: nil
 attribute :type, kind_of: Symbol, default: nil
 attribute :server, kind_of: String, default: nil
 attribute :aem_version, kind_of: String, default: nil
+attribute :replicator_params, kind_of: Array, default: []


### PR DESCRIPTION
I've updated the replicator provider by removing "jcr:content" from the agent_id_param, as it's not needed. I've also added in another function in the aem_helpers.rb to apply custom replicator params, typically used specifically for flush agents. 