### PR TITLE
new command for listing agents in 6.4

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -75,7 +75,8 @@ default[:aem][:commands] = {
         '5.4' => 'curl -u <%=local_user%>:<%=local_password%> -X DELETE http://localhost:<%=local_port%>/etc/replication/agents.<%=server%>/<%=h%>'
       },
       list: {
-        '5.4' => 'curl -u <%=local_user%>:<%=local_password%> http://localhost:<%=local_port%>/etc/replication.infinity.json'
+        '5.4' => 'curl -u <%=local_user%>:<%=local_password%> http://localhost:<%=local_port%>/etc/replication.infinity.json',
+        '6.4' => 'curl -u <%=local_user%>:<%=local_password%> http://localhost:<%=local_port%>/etc/replication.agents.<%=agent%>.infinity.json'
       }
     }
   },

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -76,7 +76,7 @@ default[:aem][:commands] = {
       },
       list: {
         '5.4' => 'curl -u <%=local_user%>:<%=local_password%> http://localhost:<%=local_port%>/etc/replication.infinity.json',
-        '6.4' => 'curl -u <%=local_user%>:<%=local_password%> http://localhost:<%=local_port%>/etc/replication.agents.<%=agent%>.infinity.json'
+        '6.4' => 'curl -u <%=local_user%>:<%=local_password%> http://localhost:<%=local_port%>/etc/replication/agents.<%=agent%>.infinity.json'
       }
     }
   },

--- a/providers/replicator.rb
+++ b/providers/replicator.rb
@@ -149,8 +149,12 @@ action :remove do
       runner.run_command
       runner.error!
 
-      list = JSON.parse(runner.stdout)
+      node_hash = JSON.parse(runner.stdout)
+      list = {}
       all_agents = []
+      # AEM 6.4 makes the agents.xxx not children of replication, so a little hackery
+      aem_version >= '6.4' ? list["agents.#{agent}"] = node_hash : list = node_hash
+
       list["agents.#{agent}"].keys.each do |key|
         all_agents << key unless key =~ /jcr/
       end


### PR DESCRIPTION
I've tested this in 6.3 and 6.4, and both properly find the replication agents.